### PR TITLE
M3 fix charts visuals

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -268,7 +268,7 @@ app_ui = ui.page_navbar(
                         """
                     ),
                     ui.card(
-                        ui.card_header(ui.strong("Crime Occurrences Across Vancouver's Neigbourhoods")),
+                        ui.card_header(ui.strong("Crime Occurrences Across Neigbourhoods")),
                         ui.output_ui("crime_map"),
                         #style="height: 100%; width: 100%;",
                         full_screen=True,


### PR DESCRIPTION
Please review this final adjustments to the plots. They should now look like this

<img width="1270" height="903" alt="image" src="https://github.com/user-attachments/assets/35008a0e-0685-4fa2-bd84-c68417127393" />


And they are reactive to the width of the window

<img width="1241" height="908" alt="image" src="https://github.com/user-attachments/assets/5ae3b33e-34ab-4253-831f-f4805b867660" />
